### PR TITLE
moleculesにコンポーネントを追加などの変更

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -12,6 +12,7 @@ const GlobalStyle = createGlobalStyle`
     }
     html{
         font-size: 62.5%;
+        background: #E5E5E5;
     }
     .story-wrapper {
         padding: 2rem;

--- a/src/components/atoms/Imgs/index.jsx
+++ b/src/components/atoms/Imgs/index.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 const Img = props => {
     const { src = "", alt = "", style } = props;
@@ -24,6 +24,27 @@ export const RoundBorderImage = imageGen({
     }
 });
 
+const imageSizePicker = props => {
+    switch (props.size) {
+        case "small":
+            return css`
+                width: 1.5rem;
+                height: 1.5rem;
+            `;
+        case "medium":
+            return css`
+                width: 2.5rem;
+                height: 2.5rem;
+            `;
+        case "large":
+            return css`
+                width: 3.5rem;
+                height: 3.5rem;
+            `;
+        default:
+    }
+};
+
 const StyledImg = styled.img`
     && {
         min-width: 1rem;
@@ -31,5 +52,6 @@ const StyledImg = styled.img`
         max-width: 5rem;
         max-height: 5rem;
         object-fit: cover;
+        ${props => imageSizePicker(props)}
     }
 `;

--- a/src/components/molecules/FormBox/index.stories.js
+++ b/src/components/molecules/FormBox/index.stories.js
@@ -1,8 +1,8 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import FormBox from ".";
-import { NormalInput, PasswordInput } from "../../atoms/Inputs";
-import { NormalButton } from "../../atoms/Buttons";
+import { NormalInput, PasswordInput } from "components/atoms/Inputs";
+import { NormalButton } from "components/atoms/Buttons";
 
 const mockProps = {
     name: "ログイン",

--- a/src/components/molecules/ImageText/index.jsx
+++ b/src/components/molecules/ImageText/index.jsx
@@ -1,0 +1,60 @@
+import React from "react";
+import styled, { css } from "styled-components";
+import { RoundImage, RoundBorderImage, Image } from "components/atoms/Imgs";
+
+const ImageText = props => {
+    const { children, image, type, size = "medium" } = props;
+    let Img;
+    switch (type) {
+        case "round":
+            Img = RoundImage;
+            break;
+        case "border":
+            Img = RoundBorderImage;
+            break;
+        default:
+            Img = Image;
+    }
+
+    return (
+        <StyledImageText>
+            <Img {...image} size={size} />
+            <StyledText size={size}>{children}</StyledText>
+        </StyledImageText>
+    );
+};
+
+const textSizePicker = props => {
+    switch (props.size) {
+        case "small":
+            return css`
+                font-size: 1rem;
+                margin-left: 0.5rem;
+            `;
+        case "medium":
+            return css`
+                font-size: 1.2rem;
+                margin-left: 0.8rem;
+            `;
+        case "large":
+            return css`
+                font-size: 1.4rem;
+                margin-left: 1rem;
+            `;
+        default:
+    }
+};
+
+const StyledImageText = styled.div`
+    && {
+        display: flex;
+        align-items: center;
+    }
+`;
+const StyledText = styled.p`
+    && {
+        ${props => textSizePicker(props)}
+    }
+`;
+
+export default ImageText;

--- a/src/components/molecules/ImageText/index.stories.js
+++ b/src/components/molecules/ImageText/index.stories.js
@@ -1,0 +1,38 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import ImageText from ".";
+
+const mockProps = {
+    image: {
+        src:
+            "https://emojipedia.org//static/img/logo/emojipedia-logo-140.0d779a8a903c.png",
+        alt: "emoji"
+    },
+    type: ""
+};
+
+storiesOf("molecules/ImageText/type", module)
+    .add("default", () => <ImageText {...mockProps}>SSTK</ImageText>)
+    .add("round", () => (
+        <ImageText {...mockProps} type="round">
+            SSTK
+        </ImageText>
+    ))
+    .add("border", () => (
+        <ImageText {...mockProps} type="border">
+            SSTK
+        </ImageText>
+    ));
+
+storiesOf("molecules/ImageText/size", module)
+    .add("small", () => (
+        <ImageText {...mockProps} size="small">
+            SSTK
+        </ImageText>
+    ))
+    .add("medium", () => <ImageText {...mockProps}>SSTK</ImageText>)
+    .add("large", () => (
+        <ImageText {...mockProps} size="large">
+            SSTK
+        </ImageText>
+    ));


### PR DESCRIPTION
以下の変更
・moleculesにコンポーネントをImageTextコンポーネントを追加
・コンポーネントのパスの指定を変更
・storybookのグローバルスタイルを変更
・atomsのImageにpropsでのsize指定を追加